### PR TITLE
Docker compose now launchs with makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+start-dev-env:
+	docker compose -f docker-compose.yaml up -d
+
+stop-dev-env:
+	docker compose -f docker-compose.yaml down
+
+all-test: stop-dev-env start-dev-env
+	sleep 4
+	powershell -Command "cd backend; npm test" || true
+
+.PHONY: all-test start-dev-env stop-dev-env

--- a/backend/config.local.yaml
+++ b/backend/config.local.yaml
@@ -1,0 +1,9 @@
+db:
+  host: localhost
+  port: 3306
+  user: user
+  password: password
+  database: videogames
+
+service:
+  port: 8082

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,11 +3,12 @@
     "version": "0.1",
     "description": "Videogames application",
     "scripts": {
-        "start": "node src/app.js",
+        "start": "node src/app.js --config config.local.yaml",
         "prestart": "",
         "unit-test": "jest src/test/unit",
         "integration-test": "mocha src/test/integration --exit",
-        "test": "npm run unit-test && npm run integration-test"
+        "test": "npm run unit-test && npm run integration-test",
+        "start-dev": "node src/app.js --config config.local.yaml"
     },
     "author": "Marcos Martínez",
     "license": "GPL-2.0-only",
@@ -16,7 +17,9 @@
         "express": "^4.21.1",
         "knex": "3.1.0",
         "mysql2": "^3.14.1",
-        "sqlite3": "5.1.7"
+        "sqlite3": "5.1.7",
+        "js-yaml": "^4.1.0",
+        "yargs"  : "^17.7.2"
     },
     "devDependencies": {
         "chai": "^4.4.1",

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -4,6 +4,7 @@ const cors = require('cors');
 const knex = require('knex');
 
 const videogames = require('./route/videogames');
+const { config } = require('./config/configuration');
 
 
 //Iniciamos la aplicación (Backend)
@@ -144,8 +145,8 @@ app.delete('/users/:userId', async(req,res) =>{
 });
 
 
-app.listen(8080, () => {
-    console.log("El backend ha iniciado correctamente en el puerto 8080");
+app.listen(config.service.port, () => {
+    console.log('El backend ha iniciado correctamente en el puerto ' + config.service.port);
 });
 
 module.exports = { app };

--- a/backend/src/config/configuration.js
+++ b/backend/src/config/configuration.js
@@ -1,0 +1,17 @@
+const yaml = require('js-yaml');
+const fs = require('fs');
+const yargs = require('yargs/yargs');
+const { hideBin } = require('yargs/helpers');
+
+
+//Lee el fichero de configuración
+let configFIle = 'config.local.yaml';
+const argv = yargs(hideBin(process.argv)).argv;
+if(argv.config != undefined) {
+    configFIle = argv.config;
+}
+const config = yaml.load(fs.readFileSync(configFIle, 'utf-8'));
+
+module.exports = {
+    config
+}

--- a/backend/src/service/videogames.js
+++ b/backend/src/service/videogames.js
@@ -1,13 +1,16 @@
 const knex = require('knex');
+const { config } = require('../config/configuration');
+
+
 
 const db = knex ({
     client: 'mysql2',
     connection: {
-        host: 'localhost',
-        port: 3306,
-        user: 'user',
-        password: 'password',
-        database: 'videogames'                 
+        host: config.db.host,
+        port: config.db.port,
+        user: config.db.user,
+        password: config.db.password,
+        database: config.db.database         
     },
     useNullAsDefault: true
 });


### PR DESCRIPTION
Configuration archive for database added.

All tests can be launched at once with docker compose using makefile.

integration test: 
-Should list all videogames -Does not work when usgin make all-test, but it works if I use npm run integration-test.
-It seems to happen the same if we POST new videogame with space withing letters: 
GTA VI -> NOT WORKING 
GTAVI -> WORKS