### PR TITLE
Testing why 1 integration tests fails in versions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,7 +18,9 @@ jobs:
       matrix:
         node-version: [20.x, 22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
+        #Some versions of Node.js may not be available in the actions/setup-node@v4 action.
+        # If you need to use a specific version of Node.js, you can specify it like this: 
+        # node-version: [20.0.0, 22.0.0]
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
GET /videogames does not connect to database, and makes this test to fail. no idea, depending on node version.