### PR TITLE
Added 6s of sleep in all-test of makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ stop-dev-env:
 	docker compose -f docker-compose.yaml down
 
 all-test: stop-dev-env start-dev-env
-	sleep 4
+	sleep 6
 	powershell -Command "cd backend; npm test" || true
 
 .PHONY: all-test start-dev-env stop-dev-env


### PR DESCRIPTION
Now, when launching docker compose + npm test, all of integration tests sucessfully completes.
4 seconds of sleep wasn´t enough to load all GET /videogames, so it was constantly giving errors of conection every time I launched make all-test